### PR TITLE
Enable -s flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Columnar slicing of large files using pattern matching
 
 # About
 `keycut` is inspired by `cut` but focuses on working with tabular files by header names (keys).
-It is intended to reduce calls to heavier scripting languages for the sole purpose of file splitting and fit into the coreutils ecosystem of bash pipeline functions.
+It is intended to fit into the coreutils ecosystem of bash pipeline functions and reduce calls to heavier scripting languages for file splitting.
 
 Like `cut`, it prints columns according to the fields selected and aims to be performant including working with larger-than-memory files.
 
@@ -14,7 +14,46 @@ Like `cut`, it prints columns according to the fields selected and aims to be pe
 All other options from `cut` are reproduced by `keycut`.
 The implementation of `-e`should be familiar to users of `grep`.
 
-Like `cut`, slicing on delimiters is done naively (and quickly) without regard for the context of potentially escaped delimiters (such as quoted commas in a CSV). For those cases, we recommend using a proper CSV parser.
+Like `cut`, slicing on delimiters is done naively (and quickly) without regard for the context of potentially escaped delimiters (such as quoted commas in a CSV). For those cases, we recommend using a more comprehensive CSV parser.
+
+# Usage
+`-k <key-names>`
+
+Selects columns by exact key, where key-names is a comma separated list of strings.
+May not be used with another selector.
+Note that columns are printed in the order they are listed.
+
+`-e <expressions>`
+
+Selects columns by regular expression where multiple expressions are separated by a newline character `\n`.
+Columns with a header satisfying any of the patterns will be printed.
+May not be used with another selector.
+
+`--complement` 
+
+After fields are selected, this setting instructs the program to print all columns which did *not* match the selection.
+
+`-d <delimiter>` 
+
+Input field delimiter, the character on which to split columns (default `\t`).
+
+`--help`
+
+Displays help information.
+
+`-output-delimiter` 
+
+Output field delimiter, the character or string which will be used to separate columns as they are printed. Defaults to match the input delimiter.
+
+`-s`
+
+Do not print lines which do not contain the field delimiter.
+The default behavior (preserved from `cut`) is to print the entirety of lines which do not contain the delimiter.
+
+`-z`
+
+Use a zero byte as the output line delimiter (instead of `\n`).
+Used mainly alongside other commands which may do the same to enforce filename compatibility.
 
 # License
-`keycut` is distributed under the MIT license and depends only the standard Go library.
+`keycut` is distributed under the MIT license and depends only on the standard Go library.

--- a/main.go
+++ b/main.go
@@ -99,7 +99,13 @@ func main() {
 	}
 
 	// Process all remaining lines
-	processLines(keyIndices, []byte(ifs), []byte(ofs), scanner, writer)
+	processLines(
+		keyIndices, 
+		[]byte(ifs), 
+		[]byte(ofs), 
+		flag_s_only_delim,
+		scanner, 
+		writer)
 	writer.Flush()
 }
 
@@ -283,12 +289,16 @@ func findKeysSimple(
 func processLines(
 	cols []int,
 	ifs, ofs []byte,
+	only_delimited bool,
 	scanner *bufio.Scanner,
 	writer *bufio.Writer,
 ) {
 	var buffer bytes.Buffer
 	for scanner.Scan() {
 		fields := bytes.Split(scanner.Bytes(), ifs)
+		if len(fields) == 1 && only_delimited {
+			continue
+		}
 		for i, pos := range cols {
 			if pos < len(fields) {
 				buffer.Write(fields[pos])


### PR DESCRIPTION
Enables the `-s` flag which will omit printing any line which wasn't split by the delimiter, regardless of what columns are requested.

Also adds usage to the README.

Closes #1.